### PR TITLE
add: onFirstVisible callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ npm i use-detector-hook
 ```
 
 ## Usage useElementDetector(ref, options?, callbacks?)
+
 ```javascript
 import { useState, useEffect, useRef } from "react";
 import { useElementDetector } from "use-detector-hook";
@@ -18,18 +19,23 @@ import { useElementDetector } from "use-detector-hook";
 // Example component
 const MyComponent = () => {
   const elementRef = useRef(null);
-  
+
   /*
     ELEMENT REF: REQUIRED
     OPTIONS: OPTIONAL
     CALLBACKS: OPTIONAL
   */
-  const isVisible = useElementDetector(elementRef, { threshold: 0.5 }, {
-    onTriggerEnter: () =>  console.log("ON TRIGGER ENTER"),
-    onTriggerExit: () => console.log("ON TRIGGER EXIT"),
-    onChangeVisibility: (visibility) => console.log(`ON CHANGE ${visibility}`)
-  });
-
+  const isVisible = useElementDetector(
+    elementRef,
+    { threshold: 0.5 },
+    {
+      onTriggerEnter: () => console.log("ON TRIGGER ENTER"),
+      onTriggerExit: () => console.log("ON TRIGGER EXIT"),
+      onChangeVisibility: (visibility) =>
+        console.log(`ON CHANGE ${visibility}`),
+      onFirstVisible: () => console.log("FIRST TIME ON VIEWPORT"),
+    }
+  );
 
   return (
     <div ref={elementRef}>
@@ -48,5 +54,4 @@ const MyComponent = () => {
   - `onChangeVisibility` (optional): Callback triggered when visibility changes.
   - `onTriggerEnter` (optional): Callback triggered when the element enters the viewport.
   - `onTriggerExit` (optional): Callback triggered when the element exits the viewport.
-
-
+  - `onFirstVisible` (optional): Callback triggered when the element enters the viewport for the first time.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,25 @@
-import { useRef, useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
-import './App.css'
-import { useElementDetector } from './hooks';
+import { useRef, useState } from "react";
+import reactLogo from "./assets/react.svg";
+import viteLogo from "/vite.svg";
+import "./App.css";
+import { useElementDetector } from "./hooks";
 
 function App() {
   const [count, setCount] = useState(0);
   const ref = useRef<HTMLDivElement>(null);
-  const isVisible = useElementDetector(ref, {threshold: 1}, {
-    onTriggerEnter: () => {
-      setCount(5000)
-    },
-    onTriggerExit: () => console.log("TRIGGER EXIT"),
-    onChangeVisibility: (visibility) => console.log(`ON CHANGE ${visibility}`)
-  });
+  const isVisible = useElementDetector(
+    ref,
+    { threshold: 1 },
+    {
+      onTriggerEnter: () => {
+        setCount(5000);
+      },
+      onTriggerExit: () => console.log("TRIGGER EXIT"),
+      onChangeVisibility: (visibility) =>
+        console.log(`ON CHANGE ${visibility}`),
+      onFirstVisible: () => console.log("FIRST TIME ON VIEWPORT"),
+    }
+  );
 
   return (
     <>
@@ -25,23 +31,31 @@ function App() {
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>
-      <h1>{isVisible ? 'Element Visible' : 'Element not visible'}</h1>
-      <div className="card" style={{backgroundColor: isVisible ? 'green' : '#fff'}}>
+      <h1>{isVisible ? "Element Visible" : "Element not visible"}</h1>
+      <div
+        className="card"
+        style={{ backgroundColor: isVisible ? "green" : "#fff" }}
+      >
         <button onClick={() => setCount((count) => count + 1)}>
           count is {count}
         </button>
-        <p>
-          ELEMENT REF
-        </p>
+        <p>ELEMENT REF</p>
       </div>
-      <div style={{height: 800, display: 'flex', justifyContent: 'center', alignItems: 'center'}}>
+      <div
+        style={{
+          height: 800,
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+        }}
+      >
         <p>Scroll</p>
       </div>
-      <p className="read-the-docs"  ref={ref}>
+      <p className="read-the-docs" ref={ref}>
         Click on the Vite and React logos to learn more
       </p>
     </>
-  )
+  );
 }
 
-export default App
+export default App;

--- a/src/hooks/useElementDetector.ts
+++ b/src/hooks/useElementDetector.ts
@@ -11,6 +11,7 @@ export interface Callbacks {
   ) => void;
   onTriggerEnter?: (ref: RefObject<HTMLElement>) => void;
   onTriggerExit?: (ref: RefObject<HTMLElement>) => void;
+  onFirstVisible?: (ref: RefObject<HTMLElement>) => void;
 }
 
 /**
@@ -26,6 +27,7 @@ export const useElementDetector = (
   callbacks?: Callbacks
 ): boolean => {
   const [isVisible, setIsVisible] = useState(false); // State to track visibility of the element
+  const [firstVisible, setFirstVisible] = useState(false); // State to track if the element is visible for the first time
 
   if (options?.threshold && options.threshold > 1) {
     throw new Error("'threshold' must be between 0 and 1");
@@ -41,6 +43,11 @@ export const useElementDetector = (
         // Handle enter and exit triggers with additional checks
         if (isIntersecting) {
           callbacks?.onTriggerEnter?.(ref);
+          // Call onFirstVisible callback if it's the first time the element is visible
+          if (!firstVisible) {
+            setFirstVisible(true);
+            callbacks?.onFirstVisible?.(ref);
+          }
         } else {
           callbacks?.onTriggerExit?.(ref);
         }
@@ -62,7 +69,7 @@ export const useElementDetector = (
         observer.unobserve(ref.current);
       }
     };
-  }, [ref]); // Re-run effect when dependencies change
+  }, [ref, firstVisible]); // Re-run effect when dependencies change
 
   return isVisible; // Return the visibility state
 };


### PR DESCRIPTION
Este PR introduce un nuevo callback opcional `onFirstVisible` al hook `useElementDetector`. Este callback se invoca cuando el elemento se vuelve visible por primera vez después de estar oculto.

Los cambios incluyen:
- Agregar `onFirstVisible` a la interfaz `Callbacks`.
- Modificar el hook `useElementDetector` para invocar `onFirstVisible` la primera vez que el elemento se vuelve visible.
- Actualizar las dependencias del `useEffect` en `useElementDetector` para incluir `firstVisible`.

Este nuevo callback proporciona una mayor flexibilidad al usar el hook `useElementDetector`, permitiendo a los desarrolladores realizar acciones específicas la primera vez que un elemento se vuelve visible.